### PR TITLE
Remove private class parameters

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,24 +2,12 @@
 #
 # This class is called from nomad::init to install the config file.
 #
-# == Parameters
-#
-# [*config_hash*]
-#   Hash for nomad to be deployed as JSON
-#
-# [*purge*]
-#   Bool. If set will make puppet remove stale config files.
-#
-class nomad::config (
-  $config_hash,
-  $purge = true,
-) {
+class nomad::config {
   if $nomad::init_style {
     case $nomad::init_style {
       'systemd' : {
         systemd::unit_file { 'nomad.service':
           content => template('nomad/nomad.systemd.erb'),
-          notify  => $nomad::notify_service,
         }
       }
       'launchd' : {
@@ -40,8 +28,8 @@ class nomad::config (
     ensure  => 'directory',
     owner   => $nomad::user,
     group   => $nomad::group,
-    purge   => $purge,
-    recurse => $purge,
+    purge   => $nomad::purge_config_dir,
+    recurse => $nomad::purge_config_dir,
   }
   -> file { 'nomad config.json':
     ensure  => file,
@@ -49,6 +37,6 @@ class nomad::config (
     owner   => $nomad::user,
     group   => $nomad::group,
     mode    => $nomad::config_mode,
-    content => nomad::sorted_json($config_hash, $nomad::pretty_config, $nomad::pretty_config_indent),
+    content => nomad::sorted_json($nomad::config_hash_real, $nomad::pretty_config, $nomad::pretty_config_indent),
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,9 +105,7 @@ class nomad (
 
   class { 'nomad::install': }
   -> class { 'nomad::config':
-    config_hash => $config_hash_real,
-    purge       => $purge_config_dir,
-    notify      => $notify_service,
+    notify => $notify_service,
   }
   -> class { 'nomad::run_service': }
   -> class { 'nomad::reload_service': }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'nomad' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts }
+      let(:facts) { os_facts.merge(service_provider: 'systemd') }
 
       # Installation Stuff
       context 'On an unsupported arch' do
@@ -20,11 +20,14 @@ describe 'nomad' do
         let(:params) {{
           :purge_config_dir => false
         }}
-        it { should contain_class('nomad::config').with(:purge => false) }
+
+        it { should contain_file('/etc/nomad').with(:purge => false,:recurse => false) }
       end
 
       context 'nomad::config should notify nomad::run_service' do
         it { should contain_class('nomad::config').that_notifies(['Class[nomad::run_service]']) }
+        it { should contain_file('/usr/local/bin/nomad').that_notifies(['Class[nomad::run_service]']) }
+        it { should contain_systemd__unit_file('nomad.service').that_notifies(['Class[nomad::run_service]']) }
       end
 
       context 'nomad::config should not notify nomad::run_service on config change' do


### PR DESCRIPTION
Most variables are already set on the main class. This takes it a step further and removes the class parameters.

It also removes the redundant notify on the unit file, as verified by the newly added test.