### PR TITLE
Allow overriding user and group used

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,15 +15,15 @@ class nomad::config {
 
   file { $nomad::config_dir:
     ensure  => 'directory',
-    owner   => 'root',
-    group   => 'root',
+    owner   => $nomad::user,
+    group   => $nomad::group,
     purge   => $nomad::purge_config_dir,
     recurse => $nomad::purge_config_dir,
   }
   -> file { 'nomad config.json':
     ensure  => file,
-    owner   => 'root',
-    group   => 'root',
+    owner   => $nomad::user,
+    group   => $nomad::group,
     path    => "${nomad::config_dir}/config.json",
     mode    => $nomad::config_mode,
     content => $_config,
@@ -31,8 +31,8 @@ class nomad::config {
   $content = join(map($nomad::env_vars) |$key, $value| { "${key}=${value}" }, "\n")
   file { "${nomad::config_dir}/nomad.env":
     ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
+    owner   => $nomad::user,
+    group   => $nomad::group,
     mode    => $nomad::config_mode,
     content => "${content}\n",
     require => File[$nomad::config_dir],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,6 +128,10 @@
 #   Determines whether to restart nomad agent on $config_hash changes. This will not affect reloads when service, check or watch configs change.
 # @param env_vars
 #   Hash of optional environment variables that should be passed to nomad
+# @param user
+#   User to run the Nomad binary as. Also used as owner of directories and config files managed by this module.
+# @param group
+#   Group to run the Nomad binary as. Also used as group of directories and config files managed by this module.
 class nomad (
   String[1] $arch,
   Boolean $purge_config_dir                      = true,
@@ -154,6 +158,8 @@ class nomad (
   Boolean $manage_service_file                   = false,
   Boolean $restart_on_change                     = true,
   Hash[String[1], String] $env_vars              = {},
+  String[1] $user                                = 'root',
+  String[1] $group                               = 'root',
 ) {
   $real_download_url = pick($download_url, "${download_url_base}${version}/${package_name}_${version}_${os}_${arch}.${download_extension}")
   $config_hash_real = deep_merge($config_defaults, $config_hash)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,8 +5,8 @@ class nomad::install {
   if $nomad::data_dir {
     file { $nomad::data_dir:
       ensure => 'directory',
-      owner  => 'root',
-      group  => 'root',
+      owner  => $nomad::user,
+      group  => $nomad::group,
       mode   => $nomad::data_dir_mode,
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -415,6 +415,63 @@ describe 'nomad' do
         it { is_expected.to contain_file('/etc/nomad.d/nomad.env').with_content(%r{TEST=foobar}) }
         it { is_expected.to contain_file('/etc/nomad.d/nomad.env').with_content(%r{BLA=blub}) }
       end
+
+      context 'With non-default user and group' do
+        context 'with defaults' do
+          let :params do
+            {
+              user: 'nomad',
+              group: 'nomad',
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/nomad.d').with(owner: 'nomad', group: 'nomad') }
+          it { is_expected.to contain_file('nomad config.json').with(owner: 'nomad', group: 'nomad') }
+        end
+
+        context 'with provided data_dir' do
+          let :params do
+            {
+              config_hash: {
+                'data_dir' => '/dir1',
+              },
+              user: 'nomad',
+              group: 'nomad',
+            }
+          end
+
+          it { is_expected.to contain_file('/dir1').with(ensure: 'directory', owner: 'nomad', group: 'nomad') }
+        end
+
+        context 'with env_vars' do
+          let :params do
+            {
+              env_vars: {
+                'TEST' => 'foobar',
+                'BLA' => 'blub',
+              },
+              user: 'nomad',
+              group: 'nomad',
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/nomad.d/nomad.env').with(content: %r{TEST=foobar}, owner: 'nomad', group: 'nomad') }
+          it { is_expected.to contain_file('/etc/nomad.d/nomad.env').with(content: %r{BLA=blub}, owner: 'nomad', group: 'nomad') }
+        end
+
+        context 'with manage_service_file = true' do
+          let :params do
+            {
+              user: 'nomad',
+              group: 'nomad',
+              manage_service_file: true,
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/systemd/system/nomad.service').with_content(%r{^User=nomad$}) }
+          it { is_expected.to contain_file('/etc/systemd/system/nomad.service').with_content(%r{^Group=nomad$}) }
+        end
+      end
     end
   end
 end

--- a/templates/nomad.systemd.erb
+++ b/templates/nomad.systemd.erb
@@ -17,6 +17,8 @@ StartLimitBurst=3
 StartLimitIntervalSec=10
 TasksMax=infinity
 OOMScoreAdjust=-1000
+User=<%= scope.lookupvar('nomad::user') %>
+Group=<%= scope.lookupvar('nomad::group') %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds two parameters to the base class, `$user` and `$group`, so one can specify which user and group should be used to run Nomad. This would allow one to run the Nomad server with a seperate user, as per upstream's recommendation: https://developer.hashicorp.com/nomad/docs/install/production/requirements#user-permissions

I used `root` as default for both parameters to not break people's existing workflows.

#### This Pull Request (PR) fixes the following issues

Fixes #66 
