### PR TITLE
use systemd to reload the daemon

### DIFF
--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -1,24 +1,16 @@
 # This class is meant to be called from certain
 # configuration changes that support reload.
 #
-# @see https://www.nomad.io/docs/agent/options.html#reloadable-configuration
+# @see https://developer.hashicorp.com/nomad/docs/configuration#configuration-reload
 #
 # @api private
 class nomad::reload_service {
   # Don't attempt to reload if we're not supposed to be running.
   # This can happen during pre-provisioning of a node.
   if $nomad::manage_service == true and $nomad::service_ensure == 'running' {
-    # Make sure we don't try to connect to 0.0.0.0, use 127.0.0.1 instead
-    # This can happen if the nomad agent RPC port is bound to 0.0.0.0
-    if $nomad::rpc_addr == '0.0.0.0' {
-      $rpc_addr = '127.0.0.1'
-    } else {
-      $rpc_addr = $nomad::rpc_addr
-    }
-
     exec { 'reload nomad service':
-      path        => [$nomad::bin_dir,'/bin','/usr/bin'],
-      command     => "nomad reload -rpc-addr=${rpc_addr}:${nomad::rpc_port}",
+      path        => ['/bin', '/usr/bin'],
+      command     => 'systemctl reload nomad',
       refreshonly => true,
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -347,7 +347,7 @@ describe 'nomad' do
       context 'When nomad is reloaded' do
         it {
           expect(subject).to contain_exec('reload nomad service').
-            with_command('nomad reload -rpc-addr=127.0.0.1:8400')
+            with_command('systemctl reload nomad')
         }
       end
 
@@ -367,7 +367,7 @@ describe 'nomad' do
 
         it {
           expect(subject).to contain_exec('reload nomad service').
-            with_command('nomad reload -rpc-addr=nomad.example.com:9999')
+            with_command('systemctl reload nomad')
         }
       end
 
@@ -382,7 +382,7 @@ describe 'nomad' do
 
         it {
           expect(subject).to contain_exec('reload nomad service').
-            with_command('nomad reload -rpc-addr=192.168.34.56:8400')
+            with_command('systemctl reload nomad')
         }
       end
 


### PR DESCRIPTION
#### Pull Request (PR) description

The command that was previously used is no longer working. 
At same time Hashicorp recommend a different method https://developer.hashicorp.com/nomad/docs/configuration#configuration-reload, which can be achieved with `systemd`. 

For the long story, please have a look at the corresponding issue: https://github.com/voxpupuli/puppet-nomad/issues/75

#### This Pull Request (PR) fixes the following issues

Fixes #75