### PR TITLE
puppet/systemd: allow 8.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 1.1.1 < 8.0.0"
+      "version_requirement": ">= 1.1.1 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- **modulesync 8.0.1**
- **modulesync 9.0.0**
- **modulesync 9.1.0**
- **modulesync 9.2.0**
- **modulesync 9.3.0**
- **puppet/systemd: allow 8.x**
